### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/springboot-elasticsearch/pom.xml
+++ b/springboot-elasticsearch/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.40</version>
+            <version>1.2.83</version>
         </dependency>
 
     </dependencies>

--- a/springboot-kafka/pom.xml
+++ b/springboot-kafka/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.40</version>
+            <version>1.2.83</version>
         </dependency>
 
 

--- a/springboot-neo4j/pom.xml
+++ b/springboot-neo4j/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.40</version>
+            <version>1.2.83</version>
         </dependency>
 
         <!--neo4j-->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.40
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.40 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS